### PR TITLE
backend-php: Don't style check sample local config files

### DIFF
--- a/.github/workflows/backend-php.yml
+++ b/.github/workflows/backend-php.yml
@@ -118,7 +118,6 @@ jobs:
           phpcs -q --report=checkstyle \
                    --standard=$GITHUB_WORKSPACE/codestyle/${{ inputs.codestyle }} \
                    --ignore=locate\.* \
-                   --extensions=php,sample \
                    ${{ inputs.phpcs-whitelist }} \
                    src/ | cs2pr
 


### PR DESCRIPTION
Sample local config files may include jinja code, which confuses phpcs and results in false errors.