### PR TITLE
php-decomposer: Lock phpstan to version 2.1.8

### DIFF
--- a/.github/workflows/php-decomposer.yml
+++ b/.github/workflows/php-decomposer.yml
@@ -292,7 +292,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.minimum-php-version }}
-          tools: phpstan
+          tools: phpstan:2.1.8
           extensions: autoload_psr-pprkut/autoload-psr@0.2.0
           ini-values: include_path='.:/usr/share/php:$GITHUB_WORKSPACE/vendor'
 


### PR DESCRIPTION
2.1.9 introduced a bug that raises false positives: https://github.com/phpstan/phpstan/issues/12793