### PR TITLE
feat: build sub-sites

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -22,6 +22,11 @@ on:
         default: '20.x'
         required: false
         type: string
+      sub-site:
+        description: 'Build a sub-website'
+        default: false
+        required: false
+        type: boolean
     secrets:
       npm_pat:
         description: The PAT for NPM registry access
@@ -33,6 +38,9 @@ on:
       artifact:
         description: "Artifact name"
         value: ${{ jobs.build.outputs.artifact }}
+      sub-artifact:
+        description: "Sub site artifact name"
+        value: ${{ jobs.build.outputs.sub-artifact }}
 
 jobs:
   build:
@@ -42,6 +50,7 @@ jobs:
       ENVIRONMENT: ${{ inputs.environment }}
     outputs:
       artifact: build-${{ inputs.node-version }}
+      sub-artifact: build-sub-${{ inputs.node-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -94,6 +103,26 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: build-${{ inputs.node-version }}
+          path: out/
+          retention-days: 1
+          include-hidden-files: true
+
+      - name: Clean build
+        if: inputs.sub-site
+        run: yarn clean
+
+      - name: Build website
+        if: inputs.sub-site
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.sentry_auth_token }}
+        run: yarn build
+
+      - name: Upload website
+        if: inputs.sub-site
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: build-sub-${{ inputs.node-version }}
           path: out/
           retention-days: 1
           include-hidden-files: true


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/web-build.yml` file to support building and handling sub-websites. The most important changes include adding new inputs, outputs, and steps to manage the sub-website build process.

### Enhancements to sub-website build process:

* Added a new input `sub-site` to specify whether to build a sub-website (`.github/workflows/web-build.yml` [.github/workflows/web-build.ymlR25-R29](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R25-R29)).
* Introduced a new output `sub-artifact` to store the sub-website build artifact (`.github/workflows/web-build.yml` [.github/workflows/web-build.ymlR41-R43](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R41-R43)).
* Updated the `jobs` section to include `sub-artifact` as an output (`.github/workflows/web-build.yml` [.github/workflows/web-build.ymlR53](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R53)).
* Added steps to clean, build, and upload the sub-website if `sub-site` input is true (`.github/workflows/web-build.yml` [.github/workflows/web-build.ymlR110-R129](diffhunk://#diff-19b023023d9d583fbe12c89870c1353adccb781f831111f536a839655eaecf94R110-R129)).