### PR TITLE
fix: add --exclude in front of images.ctfassets.net

### DIFF
--- a/.github/workflows/web-link-checker.yml
+++ b/.github/workflows/web-link-checker.yml
@@ -25,4 +25,4 @@ jobs:
             with:
               fail: true
               failIfEmpty: true
-              args: --base out/ --verbose --no-progress --exclude 'videos\.ctfassets\.net' 'images\.ctfassets\.net' './**/*.html' 
+              args: --base out/ --verbose --no-progress --exclude 'videos\.ctfassets\.net' --exclude 'images\.ctfassets\.net' './**/*.html' 


### PR DESCRIPTION
This change fixes the failing CI jobs that uses this workflow and has references to images.ctfassets.net.