### PR TITLE
feat: add optional `MIGRATIONS_DIR` input to `web-migrate-contentful` workflow

### DIFF
--- a/.github/workflows/web-migrate-contentful.yml
+++ b/.github/workflows/web-migrate-contentful.yml
@@ -16,6 +16,10 @@ on:
         description: 'The contentful space ID'
         required: true
         type: string
+      migrations_dir:
+        description: 'Optional path to the directory containing migrations'
+        required: false
+        type: string
     secrets:
       amazon_role:
         description: The AWS role to assume to store state in S3
@@ -67,4 +71,11 @@ jobs:
           MIGRATIONS_STATE_FILE_STORAGE: s3
           MIGRATIONS_STATE_FILE_BUCKET: '${{ github.repository_owner }}-contentful-migrations'
           MIGRATIONS_STATE_FILE: migrated.json
-        run: yarn migrate
+        # Use a shell block so we only export MIGRATIONS_DIR when the caller provides one,
+        # preserving existing workflows that already inject the env before this step.
+        run: |
+          if [ -n "${{ inputs.migrations_dir }}" ]; then
+            export MIGRATIONS_DIR="${{ inputs.migrations_dir }}"
+          fi
+
+          yarn migrate

--- a/.github/workflows/web-migrate-contentful.yml
+++ b/.github/workflows/web-migrate-contentful.yml
@@ -68,14 +68,15 @@ jobs:
           CONTENTFUL_ENVIRONMENT: ${{ inputs.contentful_environment != '' && inputs.contentful_environment || inputs.environment }}
           CONTENTFUL_SPACE: ${{ inputs.contentful_space_id }}
           CONTENTFUL_MANAGEMENT_API_TOKEN: ${{ secrets.contentful_management_api_token }}
+          MIGRATIONS_DIR_INPUT: ${{ inputs.migrations_dir }}
           MIGRATIONS_STATE_FILE_STORAGE: s3
           MIGRATIONS_STATE_FILE_BUCKET: '${{ github.repository_owner }}-contentful-migrations'
           MIGRATIONS_STATE_FILE: migrated.json
         # Use a shell block so we only export MIGRATIONS_DIR when the caller provides one,
         # preserving existing workflows that already inject the env before this step.
         run: |
-          if [ -n "${{ inputs.migrations_dir }}" ]; then
-            export MIGRATIONS_DIR="${{ inputs.migrations_dir }}"
+          if [ -n "$MIGRATIONS_DIR_INPUT" ]; then
+            export MIGRATIONS_DIR="$MIGRATIONS_DIR_INPUT"
           fi
 
           yarn migrate

--- a/.github/workflows/web-migrate-contentful.yml
+++ b/.github/workflows/web-migrate-contentful.yml
@@ -17,7 +17,8 @@ on:
         required: true
         type: string
       migrations_dir:
-        description: 'Optional path to the directory containing migrations'
+        description: 'Path to the directory containing migrations'
+        default: './src/contentful/migrations'
         required: false
         type: string
     secrets:
@@ -68,15 +69,8 @@ jobs:
           CONTENTFUL_ENVIRONMENT: ${{ inputs.contentful_environment != '' && inputs.contentful_environment || inputs.environment }}
           CONTENTFUL_SPACE: ${{ inputs.contentful_space_id }}
           CONTENTFUL_MANAGEMENT_API_TOKEN: ${{ secrets.contentful_management_api_token }}
-          MIGRATIONS_DIR_INPUT: ${{ inputs.migrations_dir }}
+          MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
           MIGRATIONS_STATE_FILE_STORAGE: s3
           MIGRATIONS_STATE_FILE_BUCKET: '${{ github.repository_owner }}-contentful-migrations'
           MIGRATIONS_STATE_FILE: migrated.json
-        # Use a shell block so we only export MIGRATIONS_DIR when the caller provides one,
-        # preserving existing workflows that already inject the env before this step.
-        run: |
-          if [ -n "$MIGRATIONS_DIR_INPUT" ]; then
-            export MIGRATIONS_DIR="$MIGRATIONS_DIR_INPUT"
-          fi
-
-          yarn migrate
+        run: yarn migrate


### PR DESCRIPTION
## Context  
LAS now uses `.env` files for environment config instead of `config/index.js`.  

Previously, env vars were injected into memory before running the migration script in GitHub Actions. Since everything now lives in `.env`, that flow no longer works.  

## Problem  
The `web-migrate-contentful.yml` action doesn’t support passing `migrations_dir`, but the [`migrate` script requires it in process.env](https://github.com/move-frontend/web-shared/blob/ae11fe5df36b60fc8dd36e6edf2972bffe12de1c/packages/migrate/src/config.ts#L16) to run.  
- [Failing run – `inputs.migrations_dir` not supported](https://github.com/framna-nl-las/las-website/actions/runs/18043034951/workflow)  
- [Failing run – `MIGRATIONS_DIR` required](https://github.com/framna-nl-las/las-website/actions/runs/18042671836/job/51345514774#step:6:94)  

## Solution  
This PR updates the workflow to source required envs from GitHub secrets/vars when set. The approach is a bit more roundabout than ideal, but necessary to avoid breaking code that assumes `MIGRATIONS_DIR` is already available in `process.env`.  
