### PR TITLE
fix: add authorization header to zizmor fetching

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Download shared config
         if: inputs.config == 'shared'
         run: |
-          curl --fail --remote-name "https://raw.githubusercontent.com/${{ env.ACTION_REPO }}/refs/heads/${{ env.ACTION_REF }}/shared-zizmor.yml"
+          curl --fail --remote-name \
+            --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://raw.githubusercontent.com/${{ env.ACTION_REPO }}/refs/heads/${{ env.ACTION_REF }}/shared-zizmor.yml"
           
           old_config=""
           if [[ -f "zizmor.yml" ]]; then


### PR DESCRIPTION
Update curl command to include authorization header for downloading shared config.