### PR TITLE
php-container-build: Fix minor naming issues

### DIFF
--- a/.github/workflows/php-app-container-build.yml
+++ b/.github/workflows/php-app-container-build.yml
@@ -55,7 +55,7 @@ jobs:
           TARGETS: ${{ inputs.targets }}
         run: |
           set -euo pipefail
-          MATRIX=$(jq --raw-input --slurp --compact-output '{target: (split("[[:space:]]+"; null) | map(select(length > 0)))}' <<< "$TARGETS")
+          MATRIX=$(jq --raw-input --slurp --compact-output '{target: (split("[[:space:],]+"; null) | map(select(length > 0)))}' <<< "$TARGETS")
           if [ "$(jq '.target | length' <<< "$MATRIX")" -eq 0 ]; then
             echo "::error::targets input must contain at least one entry"
             exit 1

--- a/.github/workflows/php-app-container-build.yml
+++ b/.github/workflows/php-app-container-build.yml
@@ -31,7 +31,7 @@ on:
     secrets:
       COMPOSER_AUTH:
         required: true
-      container_deploy_role:
+      CONTAINER_DEPLOY_ROLE:
         required: true
         description: ARN for the AWS role that allows pushing to ECR
 
@@ -128,7 +128,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
-          role-to-assume: ${{ secrets.container_deploy_role }}
+          role-to-assume: ${{ secrets.CONTAINER_DEPLOY_ROLE }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/php-infra-container-build.yml
+++ b/.github/workflows/php-infra-container-build.yml
@@ -45,7 +45,7 @@ jobs:
           TARGETS: ${{ inputs.targets }}
         run: |
           set -euo pipefail
-          MATRIX=$(jq --raw-input --slurp --compact-output '{target: (split("[[:space:]]+"; null) | map(select(length > 0)))}' <<< "$TARGETS")
+          MATRIX=$(jq --raw-input --slurp --compact-output '{target: (split("[[:space:],]+"; null) | map(select(length > 0)))}' <<< "$TARGETS")
           if [ "$(jq '.target | length' <<< "$MATRIX")" -eq 0 ]; then
             echo "::error::targets input must contain at least one entry"
             exit 1

--- a/.github/workflows/php-infra-container-build.yml
+++ b/.github/workflows/php-infra-container-build.yml
@@ -21,7 +21,7 @@ on:
         type: string
         default: 'namespace-profile-ubuntu-nl'
     secrets:
-      container_deploy_role:
+      CONTAINER_DEPLOY_ROLE:
         required: true
         description: ARN for the AWS role that allows pushing to ECR
 
@@ -82,7 +82,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
-          role-to-assume: ${{ secrets.container_deploy_role }}
+          role-to-assume: ${{ secrets.CONTAINER_DEPLOY_ROLE }}
           aws-region: ${{ inputs.aws-region }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
This removes commas from job names (and potentially other places) as well as syncs the deploy role secret name with the actual casing used