### PR TITLE
shared-zizmor: Trust framna-nl-backend/actions subpath actions

### DIFF
--- a/shared-zizmor.yml
+++ b/shared-zizmor.yml
@@ -18,3 +18,4 @@ rules:
         move-agency/actions-templates/.github/workflows/web-cloudfront-deploy.yml: any
         move-agency/actions-templates/.github/workflows/web-sonarqube.yml: any
         move-agency/actions-templates/.github/workflows/pr-file-conflict-checker.yml: any
+        framna-nl-backend/actions/*: any


### PR DESCRIPTION
The unpinned-uses audit flagged `framna-nl-backend/actions/<sub>@main` references (e.g. phpunit-config, reviewboard) because no policy matched them, falling back to the blanket hash-pin requirement.

Add a `framna-nl-backend/actions/*: any` policy so all subpath actions in our own actions repo are trusted without hash-pinning. The trailing `/*` is required: a bare `owner/repo` pattern does not match subpath references like `.../phpunit-config@main`.