### PR TITLE
fix(ci): hoist NODE_AUTH_TOKEN to job level for remaining yarn workflows

### DIFF
--- a/.github/workflows/web-accessibility-check.yml
+++ b/.github/workflows/web-accessibility-check.yml
@@ -16,6 +16,8 @@ jobs:
   axe:
     runs-on: ubuntu-latest
     name: "Axe accessibility check"
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,8 +32,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
 
       - name: Get Chromium version
         run: |

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -53,6 +53,7 @@ jobs:
     name: "Build (node ${{ inputs.node-version }})"
     env:
       ENVIRONMENT_NAME: ${{ inputs.environment }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     outputs:
       artifact: build-${{ inputs.node-version }}
       sub-artifact: build-sub-${{ inputs.node-version }}
@@ -115,8 +116,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
 
       - name: Install Phrase CLI
         if: hashFiles('.phraseapp.yml') != '' && !inputs.fast-runner

--- a/.github/workflows/web-cloudfront-deploy.yml
+++ b/.github/workflows/web-cloudfront-deploy.yml
@@ -45,6 +45,7 @@ jobs:
     name: "Deploy to ${{ inputs.environment }} CloudFront"
     env:
       ENVIRONMENT_NAME: ${{ inputs.environment }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     steps:
       - name: Lowercase enviromnent name
         run: |
@@ -65,8 +66,6 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/web-contentful-algolia-search.yml
+++ b/.github/workflows/web-contentful-algolia-search.yml
@@ -38,6 +38,8 @@ jobs:
   index_search:
     runs-on: ubuntu-latest
     name: 'Index Search Algolia (node ${{ inputs.node-version }})'
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,8 +54,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
 
       - name: Get Contentful environment name
         env:

--- a/.github/workflows/web-migrate-contentful.yml
+++ b/.github/workflows/web-migrate-contentful.yml
@@ -44,6 +44,7 @@ jobs:
     name: 'Contentful migration'
     env:
       ENVIRONMENT_NAME: ${{ inputs.environment }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     steps:
       - name: Lowercase enviromnent name
         run: |
@@ -61,8 +62,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/web-sonarqube.yml
+++ b/.github/workflows/web-sonarqube.yml
@@ -20,6 +20,8 @@ jobs:
     sonarqube:
         runs-on: ubuntu-latest
         name: "SonarQube scan (node ${{ inputs.node-version }})"
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.npm_pat }}
         steps:
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -37,8 +39,6 @@ jobs:
 
             - name: Install dependencies
               run: yarn install --production=false --frozen-lockfile
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.npm_pat }}
 
             - name: Run test coverage
               run: yarn coverage

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     name: "Test (node ${{ matrix.node-version }})"
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     permissions:
       contents: read
     strategy:
@@ -35,8 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --production=false --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
 
       - name: Run unit tests
         run: yarn test

--- a/.github/workflows/web-vercel-deploy.yml
+++ b/.github/workflows/web-vercel-deploy.yml
@@ -35,6 +35,7 @@ jobs:
     name: 'Preview deploy'
     env:
       ENVIRONMENT_NAME: ${{ inputs.environment }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
     steps:
       - name: Lowercase enviromnent name
         run: |
@@ -51,8 +52,6 @@ jobs:
           registry-url: https://npm.pkg.github.com
           cache: yarn
       - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PAT }}
         run: yarn install --production=false --frozen-lockfile
       - name: Deploy preview
         env:


### PR DESCRIPTION
## Problem

Since `actions/setup-node` was bumped 6.4.0 → 7.0.0, CI jobs using `cache: yarn` fail with:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

With `registry-url` set, setup-node writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`. v7 runs `yarn cache dir` **inside the setup-node step** for cache detection, which reads that `.npmrc` and tries to substitute the placeholder. But `NODE_AUTH_TOKEN` was only exported on the later *Install dependencies* step, so the substitution fails and the job errors out. v6.4.0 didn't trigger this at that point.

## Fix

Hoist `NODE_AUTH_TOKEN` to **job-level `env`** so the token is present when setup-node runs its cache detection, and remove the now-redundant step-level `env`. This mirrors the already-merged fix in `web-lint` (c527bed).

## Affected workflows

- `web-build.yml`
- `web-test.yml`
- `web-sonarqube.yml`
- `web-vercel-deploy.yml`
- `web-cloudfront-deploy.yml`
- `web-migrate-contentful.yml`
- `web-contentful-algolia-search.yml`
- `web-accessibility-check.yml`

(`web-lint.yml` was already fixed separately.)

All changed files validated as parseable YAML.