### PR TITLE
chore: add CODEOWNERS for workflow templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Code owners for the shared GitHub Actions workflow templates.
+#
+# A team listed here is automatically requested for review on any PR that
+# touches the matching files (including Dependabot PRs). With branch
+# protection's "Require review from Code Owners" enabled, their approval is
+# required before merge. Patterns are evaluated top to bottom; the last
+# matching pattern wins.
+
+# Web / frontend workflow templates
+/.github/workflows/web-*.yml            @Move-Agency/web
+
+# Backend / PHP workflow templates
+/.github/workflows/php-*.yml            @Move-Agency/backend
+/.github/workflows/functional-*.yml     @Move-Agency/backend
+/.github/workflows/lunr-*.yml           @Move-Agency/backend
+/.github/workflows/phpunit-*.yml        @Move-Agency/backend
+/.github/workflows/build-phpdraft-apidoc.yml    @Move-Agency/backend
+/.github/workflows/deploy-phpdraft-apidoc.yml   @Move-Agency/backend
+/.github/workflows/sqlfluff.yml         @Move-Agency/backend
+
+# Shared CI, security and infrastructure tooling (used by both web and backend)
+/.github/workflows/actionlint*.yml                  @Move-Agency/ci-ops
+/.github/workflows/zizmor*.yml                       @Move-Agency/ci-ops
+/.github/workflows/trufflehog*.yml                   @Move-Agency/ci-ops
+/.github/workflows/pr-file-conflict-checker*.yml     @Move-Agency/ci-ops
+/.github/workflows/typos.yml                         @Move-Agency/ci-ops
+/.github/workflows/ec-checker.yml                    @Move-Agency/ci-ops
+/.github/workflows/tf-*.yml                          @Move-Agency/ci-ops


### PR DESCRIPTION
  ## What                                                                                                                                                                                                  
                                                                                                                                                                                                           
  Adds a `.github/CODEOWNERS` that maps each workflow template to the team that owns it, so any PR touching a template automatically requests review from the people who actually consume it.              
                                                                                                                                                                                                           
  ## Why                                                                                                                                                                                                   
                                                                                                                                                                                                           
  Recently a few Dependabot bumps were merged here after the checks passed, but they broke the web CI workflows downstream (the `actions/setup-node` 6→7 bump). CI on this repo only lints the YAML statically (actionlint, zizmor, etc.) — it doesn't run the reusable workflows, so a green check here doesn't mean a template still works for its consumers. `CODEOWNERS` routes review to the team that would catch that, and in particular stops web-only templates from being merged without web-team eyes.                                                                                                    
                                                                                                                                                                                                           
  ## Ownership                                                                                                                                                                                             
                                                                                                                                                                                                           
  - `web-*.yml` → `@Move-Agency/web`                                                                                                                                                                        
  - php / functional / lunr / phpunit / phpdraft / sqlfluff → `@Move-Agency/backend`                                                                                                                         
  - shared CI / security / infra tooling (actionlint, zizmor, trufflehog, pr-file-conflict-checker, typos, ec-checker, tf-*) → `@Move-Agency/ci-ops`                                                         
                                                                                                                                                                                                           
  ## Note on the merge gate                                                                                                                                                                                
                                                                                                                                                                                                           
  The file on its own only auto-requests reviewers. It becomes an actual merge requirement once "Require review from Code Owners" is enabled in this repo's branch protection, which needs an admin.       
                                                                                                                                                                                                           
  ## Open questions                                                                                                                                                                                        
                                                                                                                                                                                                           
  I've left a few questions inline on the relevant lines for reviewers.