### PR TITLE
fix(ci): resolve root-relative links with --root-dir in link checker

### DIFF
--- a/.github/workflows/web-link-checker.yml
+++ b/.github/workflows/web-link-checker.yml
@@ -25,4 +25,4 @@ jobs:
             with:
               fail: true
               failIfEmpty: true
-              args: --base out/ --verbose --no-progress --exclude 'videos\.ctfassets\.net' --exclude 'images\.ctfassets\.net' './**/*.html' 
+              args: --root-dir ${{ github.workspace }}/out --verbose --no-progress --exclude 'videos\.ctfassets\.net' --exclude 'images\.ctfassets\.net' './**/*.html' 


### PR DESCRIPTION
lychee-action v2.9.0 moved the bundled lychee CLI from v0.23.0 to v0.24.2, and the newer CLI rejects a relative --base:

  invalid value 'out/' for '--base <BASE>': Base must either be a full URL
  (with scheme) or an absolute local path.

That fails the link-checker job for every caller of this workflow. Static exports emit root-relative links, which v0.24.x resolves via --root-dir rather than --base, so switch to --root-dir with an absolute workspace path. --base is additionally deprecated in v0.24.2 in favour of --base-url.